### PR TITLE
Switch layouts and providers to client components

### DIFF
--- a/src/app/[lang]/(blank-layout-pages)/(guest-only)/layout.tsx
+++ b/src/app/[lang]/(blank-layout-pages)/(guest-only)/layout.tsx
@@ -1,3 +1,7 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
 // Type Imports
 import type { ChildrenType } from '@core/types'
 import type { Locale } from '@configs/i18n'
@@ -5,8 +9,8 @@ import type { Locale } from '@configs/i18n'
 // HOC Imports
 import GuestOnlyRoute from '@/hocs/GuestOnlyRoute'
 
-const Layout = async (props: ChildrenType & { params: Promise<{ lang: Locale }> }) => {
-  const params = await props.params
+const Layout = (props: ChildrenType) => {
+  const params = useParams<{ lang: Locale }>()
 
   const { children } = props
 

--- a/src/app/[lang]/(blank-layout-pages)/layout.tsx
+++ b/src/app/[lang]/(blank-layout-pages)/layout.tsx
@@ -1,5 +1,10 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+
 // Type Imports
-import type { ChildrenType } from '@core/types'
+import type { ChildrenType, SystemMode } from '@core/types'
 import type { Locale } from '@configs/i18n'
 
 // Component Imports
@@ -10,19 +15,21 @@ import BlankLayout from '@layouts/BlankLayout'
 import { i18n } from '@configs/i18n'
 
 // Util Imports
-import { getSystemMode } from '@core/utils/serverHelpers'
+import { getSystemModeBrowser } from '@/utils/browserHelpers'
 
-type Props = ChildrenType & {
-  params: Promise<{ lang: Locale }>
-}
+type Props = ChildrenType
 
-const Layout = async (props: Props) => {
-  const params = await props.params
+const Layout = (props: Props) => {
   const { children } = props
+  const params = useParams<{ lang: Locale }>()
 
-  // Vars
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    setSystemMode(getSystemModeBrowser())
+  }, [])
+
   const direction = i18n.langDirection[params.lang]
-  const systemMode = await getSystemMode()
 
   return (
     <Providers direction={direction}>

--- a/src/app/[lang]/(dashboard)/(private)/layout.tsx
+++ b/src/app/[lang]/(dashboard)/(private)/layout.tsx
@@ -1,8 +1,13 @@
+"use client"
+
 // MUI Imports
 import Button from '@mui/material/Button'
 
 // Type Imports
-import type { ChildrenType } from '@core/types'
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+
+import type { ChildrenType, Mode, SystemMode } from '@core/types'
 import type { Locale } from '@configs/i18n'
 
 // Layout Imports
@@ -25,19 +30,25 @@ import AuthGuard from '@/hocs/AuthGuard'
 import { i18n } from '@configs/i18n'
 
 // Util Imports
-import { getDictionary } from '@/utils/getDictionary'
-import { getMode, getSystemMode } from '@core/utils/serverHelpers'
+import { getDictionaryBrowser, getModeBrowser, getSystemModeBrowser } from '@/utils/browserHelpers'
 
-const Layout = async (props: ChildrenType & { params: Promise<{ lang: Locale }> }) => {
-  const params = await props.params
-
+const Layout = (props: ChildrenType) => {
   const { children } = props
+  const params = useParams<{ lang: Locale }>()
 
-  // Vars
+  const [dictionary, setDictionary] = useState<any>()
+  const [mode, setMode] = useState<Mode>('light')
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    getDictionaryBrowser(params.lang as Locale).then(setDictionary)
+    setMode(getModeBrowser())
+    setSystemMode(getSystemModeBrowser())
+  }, [params.lang])
+
   const direction = i18n.langDirection[params.lang]
-  const dictionary = await getDictionary(params.lang)
-  const mode = await getMode()
-  const systemMode = await getSystemMode()
+
+  if (!dictionary) return null
 
   return (
     <Providers direction={direction}>

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 // Next Imports
-import { headers } from 'next/headers'
+import { useParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 // MUI Imports
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
@@ -8,7 +11,7 @@ import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
 import 'react-perfect-scrollbar/dist/css/styles.css'
 
 // Type Imports
-import type { ChildrenType } from '@core/types'
+import type { ChildrenType, SystemMode } from '@core/types'
 import type { Locale } from '@configs/i18n'
 
 // Component Imports
@@ -20,7 +23,7 @@ import TranslationWrapper from '@/hocs/TranslationWrapper'
 import { i18n } from '@configs/i18n'
 
 // Util Imports
-import { getSystemMode } from '@core/utils/serverHelpers'
+import { getSystemModeBrowser } from '@/utils/browserHelpers'
 
 // Style Imports
 import '@/app/globals.css'
@@ -33,18 +36,20 @@ export const metadata = {
   description: 'Materialize - Material Next.js Admin Template'
 }
 
-const RootLayout = async (props: ChildrenType & { params: Promise<{ lang: Locale }> }) => {
-  const params = await props.params
-
+const RootLayout = (props: ChildrenType) => {
   const { children } = props
+  const params = useParams<{ lang: Locale }>()
 
-  // Vars
-  const headersList = await headers()
-  const systemMode = await getSystemMode()
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    setSystemMode(getSystemModeBrowser())
+  }, [])
+
   const direction = i18n.langDirection[params.lang]
 
   return (
-    <TranslationWrapper headersList={headersList} lang={params.lang}>
+    <TranslationWrapper lang={params.lang}>
       <html id='__next' lang={params.lang} dir={direction} suppressHydrationWarning>
         <body className='flex is-full min-bs-full flex-auto flex-col'>
           <InitColorSchemeScript attribute='data' defaultMode={systemMode} />

--- a/src/app/front-pages/layout.tsx
+++ b/src/app/front-pages/layout.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 // MUI Imports
 import Button from '@mui/material/Button'
 import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
@@ -6,7 +8,7 @@ import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
 import 'react-perfect-scrollbar/dist/css/styles.css'
 
 // Type Imports
-import type { ChildrenType } from '@core/types'
+import type { ChildrenType, SystemMode } from '@core/types'
 
 // Context Imports
 import { IntersectionProvider } from '@/contexts/intersectionContext'
@@ -18,7 +20,8 @@ import FrontLayout from '@components/layout/front-pages'
 import ScrollToTop from '@core/components/scroll-to-top'
 
 // Util Imports
-import { getSystemMode } from '@core/utils/serverHelpers'
+import { useEffect, useState } from 'react'
+import { getSystemModeBrowser } from '@/utils/browserHelpers'
 
 // Style Imports
 import '@/app/globals.css'
@@ -31,9 +34,12 @@ export const metadata = {
   description: 'Materialize - Material Next.js Admin Template'
 }
 
-const Layout = async ({ children }: ChildrenType) => {
-  // Vars
-  const systemMode = await getSystemMode()
+const Layout = ({ children }: ChildrenType) => {
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    setSystemMode(getSystemModeBrowser())
+  }, [])
 
   return (
     <html id='__next' suppressHydrationWarning>

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,5 +1,10 @@
+'use client'
+
+// React Imports
+import { useEffect, useState } from 'react'
+
 // Type Imports
-import type { ChildrenType, Direction } from '@core/types'
+import type { ChildrenType, Direction, Mode, SystemMode } from '@core/types'
 
 // Context Imports
 import { NextAuthProvider } from '@/contexts/nextAuthProvider'
@@ -12,20 +17,28 @@ import ReduxProvider from '@/redux-store/ReduxProvider'
 import AppReactToastify from '@/libs/styles/AppReactToastify'
 
 // Util Imports
-import { getMode, getSettingsFromCookie, getSystemMode } from '@core/utils/serverHelpers'
+import {
+  getModeBrowser,
+  getSettingsFromCookieBrowser,
+  getSystemModeBrowser
+} from '@/utils/browserHelpers'
 
 type Props = ChildrenType & {
   direction: Direction
 }
 
-const Providers = async (props: Props) => {
-  // Props
+const Providers = (props: Props) => {
   const { children, direction } = props
 
-  // Vars
-  const mode = await getMode()
-  const settingsCookie = await getSettingsFromCookie()
-  const systemMode = await getSystemMode()
+  const [mode, setMode] = useState<Mode>('light')
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+  const [settingsCookie, setSettingsCookie] = useState<any>(null)
+
+  useEffect(() => {
+    setMode(getModeBrowser())
+    setSystemMode(getSystemModeBrowser())
+    setSettingsCookie(getSettingsFromCookieBrowser())
+  }, [])
 
   return (
     <NextAuthProvider basePath={process.env.NEXTAUTH_BASEPATH}>

--- a/src/hocs/TranslationWrapper.tsx
+++ b/src/hocs/TranslationWrapper.tsx
@@ -1,6 +1,6 @@
-// Next Imports
-import type { headers } from 'next/headers'
+'use client'
 
+// Next Imports
 // Type Imports
 import type { Locale } from '@configs/i18n'
 import type { ChildrenType } from '@core/types'
@@ -14,9 +14,7 @@ import { i18n } from '@configs/i18n'
 // ℹ️ We've to create this array because next.js makes request with `_next` prefix for static/asset files
 const invalidLangs = ['_next']
 
-const TranslationWrapper = (
-  props: { headersList: Awaited<ReturnType<typeof headers>>; lang: Locale } & ChildrenType
-) => {
+const TranslationWrapper = (props: { lang: Locale } & ChildrenType) => {
   const doesLangExist = i18n.locales.includes(props.lang)
 
   // ℹ️ This doesn't mean MISSING, it means INVALID

--- a/src/utils/browserHelpers.ts
+++ b/src/utils/browserHelpers.ts
@@ -1,0 +1,48 @@
+import themeConfig from '@configs/themeConfig'
+import type { Mode, SystemMode } from '@core/types'
+import type { Settings } from '@core/contexts/settingsContext'
+import type { Locale } from '@configs/i18n'
+
+const getCookieValue = (name: string): string | undefined => {
+  if (typeof document === 'undefined') return undefined
+  const match = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${name}=`))
+
+  return match ? decodeURIComponent(match.split('=')[1]) : undefined
+}
+
+export const getSettingsFromCookieBrowser = (): Settings => {
+  try {
+    const cookie = getCookieValue(themeConfig.settingsCookieName) || '{}'
+    return JSON.parse(cookie)
+  } catch {
+    return {} as Settings
+  }
+}
+
+export const getModeBrowser = (): Mode => {
+  const settingsCookie = getSettingsFromCookieBrowser()
+  return (settingsCookie.mode || themeConfig.mode) as Mode
+}
+
+export const getSystemModeBrowser = (): SystemMode => {
+  const mode = getModeBrowser()
+  const colorPref = (getCookieValue('colorPref') || 'light') as SystemMode
+  return (mode === 'system' ? colorPref : mode) || 'light'
+}
+
+export const getServerModeBrowser = (): Mode => {
+  const mode = getModeBrowser()
+  const systemMode = getSystemModeBrowser()
+  return (mode === 'system' ? systemMode : mode) as Mode
+}
+
+export const getSkinBrowser = (): string => {
+  const settingsCookie = getSettingsFromCookieBrowser()
+  return settingsCookie.skin || 'default'
+}
+
+export const getDictionaryBrowser = async (locale: Locale) => {
+  return (await import(`@/data/dictionaries/${locale}.json`)).default
+}


### PR DESCRIPTION
## Summary
- convert translation wrapper to client component
- add browser-based helpers for mode, settings, and translations
- update all layout files to use client-side helpers
- convert Providers to a client component with `useEffect`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686995b21544832abc07d1ec99f37bee