### PR TITLE
Fix metadata export in client layouts

### DIFF
--- a/src/app/[lang]/RootLayoutClient.tsx
+++ b/src/app/[lang]/RootLayoutClient.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+// Next Imports
+import { useParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+// MUI Imports
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
+
+// Third-party Imports
+import 'react-perfect-scrollbar/dist/css/styles.css'
+
+// Type Imports
+import type { ChildrenType, SystemMode } from '@core/types'
+import type { Locale } from '@configs/i18n'
+
+// Component Imports
+
+// HOC Imports
+import TranslationWrapper from '@/hocs/TranslationWrapper'
+
+// Config Imports
+import { i18n } from '@configs/i18n'
+
+// Util Imports
+import { getSystemModeBrowser } from '@/utils/browserHelpers'
+
+// Style Imports
+import '@/app/globals.css'
+
+// Generated Icon CSS Imports
+import '@assets/iconify-icons/generated-icons.css'
+
+const RootLayoutClient = (props: ChildrenType) => {
+  const { children } = props
+  const params = useParams<{ lang: Locale }>()
+
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    setSystemMode(getSystemModeBrowser())
+  }, [])
+
+  const direction = i18n.langDirection[params.lang]
+
+  return (
+    <TranslationWrapper lang={params.lang}>
+      <html id='__next' lang={params.lang} dir={direction} suppressHydrationWarning>
+        <body className='flex is-full min-bs-full flex-auto flex-col'>
+          <InitColorSchemeScript attribute='data' defaultMode={systemMode} />
+          {children}
+        </body>
+      </html>
+    </TranslationWrapper>
+  )
+}
+
+export default RootLayoutClient

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,63 +1,15 @@
-'use client'
+import type { Metadata } from 'next'
+import type { ChildrenType } from '@core/types'
 
-// Next Imports
-import { useParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import RootLayoutClient from './RootLayoutClient'
 
-// MUI Imports
-import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
-
-// Third-party Imports
-import 'react-perfect-scrollbar/dist/css/styles.css'
-
-// Type Imports
-import type { ChildrenType, SystemMode } from '@core/types'
-import type { Locale } from '@configs/i18n'
-
-// Component Imports
-
-// HOC Imports
-import TranslationWrapper from '@/hocs/TranslationWrapper'
-
-// Config Imports
-import { i18n } from '@configs/i18n'
-
-// Util Imports
-import { getSystemModeBrowser } from '@/utils/browserHelpers'
-
-// Style Imports
-import '@/app/globals.css'
-
-// Generated Icon CSS Imports
-import '@assets/iconify-icons/generated-icons.css'
-
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Materialize - Material Next.js Admin Template',
   description: 'Materialize - Material Next.js Admin Template'
 }
 
-const RootLayout = (props: ChildrenType) => {
-  const { children } = props
-  const params = useParams<{ lang: Locale }>()
-
-  const [systemMode, setSystemMode] = useState<SystemMode>('light')
-
-  useEffect(() => {
-    setSystemMode(getSystemModeBrowser())
-  }, [])
-
-  const direction = i18n.langDirection[params.lang]
-
-  return (
-    <TranslationWrapper lang={params.lang}>
-      <html id='__next' lang={params.lang} dir={direction} suppressHydrationWarning>
-        <body className='flex is-full min-bs-full flex-auto flex-col'>
-          <InitColorSchemeScript attribute='data' defaultMode={systemMode} />
-          {children}
-        </body>
-      </html>
-    </TranslationWrapper>
-  )
+const Layout = (props: ChildrenType) => {
+  return <RootLayoutClient {...props} />
 }
 
-export default RootLayout
+export default Layout

--- a/src/app/front-pages/LayoutClient.tsx
+++ b/src/app/front-pages/LayoutClient.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+// MUI Imports
+import Button from '@mui/material/Button'
+import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
+
+// Third-party Imports
+import 'react-perfect-scrollbar/dist/css/styles.css'
+
+// Type Imports
+import type { ChildrenType, SystemMode } from '@core/types'
+
+// Context Imports
+import { IntersectionProvider } from '@/contexts/intersectionContext'
+
+// Component Imports
+import Providers from '@components/Providers'
+import BlankLayout from '@layouts/BlankLayout'
+import FrontLayout from '@components/layout/front-pages'
+import ScrollToTop from '@core/components/scroll-to-top'
+
+// Util Imports
+import { useEffect, useState } from 'react'
+import { getSystemModeBrowser } from '@/utils/browserHelpers'
+
+// Style Imports
+import '@/app/globals.css'
+
+// Generated Icon CSS Imports
+import '@assets/iconify-icons/generated-icons.css'
+
+const LayoutClient = ({ children }: ChildrenType) => {
+  const [systemMode, setSystemMode] = useState<SystemMode>('light')
+
+  useEffect(() => {
+    setSystemMode(getSystemModeBrowser())
+  }, [])
+
+  return (
+    <html id='__next' suppressHydrationWarning>
+      <body className='flex is-full min-bs-full flex-auto flex-col'>
+        <InitColorSchemeScript attribute='data' defaultMode={systemMode} />
+        <Providers direction='ltr'>
+          <BlankLayout systemMode={systemMode}>
+            <IntersectionProvider>
+              <FrontLayout>
+                {children}
+                <ScrollToTop className='mui-fixed'>
+                  <Button
+                    variant='contained'
+                    className='is-10 bs-10 rounded-full p-0 min-is-0 flex items-center justify-center'
+                  >
+                    <i className='ri-arrow-up-line' />
+                  </Button>
+                </ScrollToTop>
+              </FrontLayout>
+            </IntersectionProvider>
+          </BlankLayout>
+        </Providers>
+      </body>
+    </html>
+  )
+}
+
+export default LayoutClient

--- a/src/app/front-pages/layout.tsx
+++ b/src/app/front-pages/layout.tsx
@@ -1,70 +1,15 @@
-'use client'
+import type { Metadata } from 'next'
+import type { ChildrenType } from '@core/types'
 
-// MUI Imports
-import Button from '@mui/material/Button'
-import InitColorSchemeScript from '@mui/material/InitColorSchemeScript'
+import LayoutClient from './LayoutClient'
 
-// Third-party Imports
-import 'react-perfect-scrollbar/dist/css/styles.css'
-
-// Type Imports
-import type { ChildrenType, SystemMode } from '@core/types'
-
-// Context Imports
-import { IntersectionProvider } from '@/contexts/intersectionContext'
-
-// Component Imports
-import Providers from '@components/Providers'
-import BlankLayout from '@layouts/BlankLayout'
-import FrontLayout from '@components/layout/front-pages'
-import ScrollToTop from '@core/components/scroll-to-top'
-
-// Util Imports
-import { useEffect, useState } from 'react'
-import { getSystemModeBrowser } from '@/utils/browserHelpers'
-
-// Style Imports
-import '@/app/globals.css'
-
-// Generated Icon CSS Imports
-import '@assets/iconify-icons/generated-icons.css'
-
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Materialize - Material Next.js Admin Template',
   description: 'Materialize - Material Next.js Admin Template'
 }
 
-const Layout = ({ children }: ChildrenType) => {
-  const [systemMode, setSystemMode] = useState<SystemMode>('light')
-
-  useEffect(() => {
-    setSystemMode(getSystemModeBrowser())
-  }, [])
-
-  return (
-    <html id='__next' suppressHydrationWarning>
-      <body className='flex is-full min-bs-full flex-auto flex-col'>
-        <InitColorSchemeScript attribute='data' defaultMode={systemMode} />
-        <Providers direction='ltr'>
-          <BlankLayout systemMode={systemMode}>
-            <IntersectionProvider>
-              <FrontLayout>
-                {children}
-                <ScrollToTop className='mui-fixed'>
-                  <Button
-                    variant='contained'
-                    className='is-10 bs-10 rounded-full p-0 min-is-0 flex items-center justify-center'
-                  >
-                    <i className='ri-arrow-up-line' />
-                  </Button>
-                </ScrollToTop>
-              </FrontLayout>
-            </IntersectionProvider>
-          </BlankLayout>
-        </Providers>
-      </body>
-    </html>
-  )
+const Layout = (props: ChildrenType) => {
+  return <LayoutClient {...props} />
 }
 
 export default Layout

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 // React Imports
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 // Type Imports
 import type { ChildrenType, Direction, Mode, SystemMode } from '@core/types'
@@ -30,15 +30,9 @@ type Props = ChildrenType & {
 const Providers = (props: Props) => {
   const { children, direction } = props
 
-  const [mode, setMode] = useState<Mode>('light')
-  const [systemMode, setSystemMode] = useState<SystemMode>('light')
-  const [settingsCookie, setSettingsCookie] = useState<any>(null)
-
-  useEffect(() => {
-    setMode(getModeBrowser())
-    setSystemMode(getSystemModeBrowser())
-    setSettingsCookie(getSettingsFromCookieBrowser())
-  }, [])
+  const [mode] = useState<Mode>(() => getModeBrowser())
+  const [systemMode] = useState<SystemMode>(() => getSystemModeBrowser())
+  const [settingsCookie] = useState<any>(() => getSettingsFromCookieBrowser())
 
   return (
     <NextAuthProvider basePath={process.env.NEXTAUTH_BASEPATH}>


### PR DESCRIPTION
## Summary
- split layout components into server/client pairs so `metadata` can be exported
- create `RootLayoutClient` and `LayoutClient` for client-side logic
- initialize provider state from cookies to prevent null setting errors

## Testing
- `pnpm lint` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699c6c8e00832aa9f54d342141cc3b